### PR TITLE
Implement AWS Signature V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![Logo](/GoFakeS3.png)
 
-[![Build Status](https://github.com/alist-org/gofakes3/workflows/build/badge.svg)](https://github.com/alist-org/gofakes3/actions?query=workflow%3Abuild)
-[![Go Report Card](https://goreportcard.com/badge/github.com/alist-org/gofakes3)](https://goreportcard.com/report/github.com/alist-org/gofakes3)
-[![GoDoc](https://pkg.go.dev/badge/github.com/alist-org/gofakes3.svg)](https://pkg.go.dev/github.com/alist-org/gofakes3)
+[![Build Status](https://github.com/akang943578/gofakes3/workflows/build/badge.svg)](https://github.com/akang943578/gofakes3/actions?query=workflow%3Abuild)
+[![Go Report Card](https://goreportcard.com/badge/github.com/akang943578/gofakes3)](https://goreportcard.com/report/github.com/akang943578/gofakes3)
+[![GoDoc](https://pkg.go.dev/badge/github.com/akang943578/gofakes3.svg)](https://pkg.go.dev/github.com/akang943578/gofakes3)
 
 This is a fork of [johannesboyne/gofakes3](https://github.com/johannesboyne/gofakes3)
 mainly for use implementing the [rclone serves3](https://rclone.org/commands/rclone_serve_s3/) command in

--- a/awscli_test.go
+++ b/awscli_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alist-org/gofakes3"
+	"github.com/akang943578/gofakes3"
 )
 
 func TestCLILsBuckets(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	xml "github.com/alist-org/gofakes3/xml"
+	xml "github.com/akang943578/gofakes3/xml"
 )
 
 // Error codes are documented here:

--- a/error_test.go
+++ b/error_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	xml "github.com/alist-org/gofakes3/xml"
+	xml "github.com/akang943578/gofakes3/xml"
 )
 
 func TestErrorCustomResponseMarshalsAsExpected(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.44.124
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46
 	github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/tools v0.2.0
 )
@@ -14,6 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alist-org/gofakes3
+module github.com/akang943578/gofakes3
 
 go 1.17
 

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,11 @@ github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 h1:GHRpF1pTW19a
 github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46/go.mod h1:uAQ5PCi+MFsC7HjREoAz1BU+Mq60+05gifQSsHSDG/8=
 github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500 h1:WnNuhiq+FOY3jNj6JXFT+eLN3CQ/oPIsDPRanvwsmbI=
 github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500/go.mod h1:+njLrG5wSeoG4Ds61rFgEzKvenR2UHbjMoDHsczxly0=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -38,7 +41,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -115,7 +115,13 @@ func (g *GoFakeS3) DelAuthKeys(p []string) {
 func (g *GoFakeS3) authMiddleware(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, rq *http.Request) {
 		if len(g.v4AuthPair) > 0 {
-			if result := signature.V4SignVerify(rq); result != signature.ErrNone {
+			result := signature.V4SignVerify(rq)
+
+			if result == signature.ErrUnsupportAlgorithm {
+				result = signature.V2SignVerify(rq)
+			}
+
+			if result != signature.ErrNone {
 				g.log.Print(LogWarn, "Access Denied:", rq.RemoteAddr, "=>", rq.URL)
 
 				resp := signature.GetAPIError(result)

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -16,8 +16,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/alist-org/gofakes3/signature"
-	xml "github.com/alist-org/gofakes3/xml"
+	"github.com/akang943578/gofakes3/signature"
+	xml "github.com/akang943578/gofakes3/xml"
 )
 
 // GoFakeS3 implements HTTP handlers for processing S3 requests and returning

--- a/gofakes3_internal_test.go
+++ b/gofakes3_internal_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	xml "github.com/alist-org/gofakes3/xml"
+	xml "github.com/akang943578/gofakes3/xml"
 )
 
 func TestHttpError(t *testing.T) {

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -16,12 +16,12 @@ import (
 	"testing"
 	"time"
 
-	xml "github.com/alist-org/gofakes3/xml"
+	xml "github.com/akang943578/gofakes3/xml"
 
+	"github.com/akang943578/gofakes3"
+	"github.com/akang943578/gofakes3/s3mem"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/alist-org/gofakes3"
-	"github.com/alist-org/gofakes3/s3mem"
 )
 
 var mockR, _ = http.NewRequest(http.MethodGet, "http://localhost:9000", nil)

--- a/init_test.go
+++ b/init_test.go
@@ -31,14 +31,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/akang943578/gofakes3"
+	"github.com/akang943578/gofakes3/s3mem"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/alist-org/gofakes3"
-	"github.com/alist-org/gofakes3/s3mem"
 )
 
 const (

--- a/messages.go
+++ b/messages.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	xml "github.com/alist-org/gofakes3/xml"
+	xml "github.com/akang943578/gofakes3/xml"
 )
 
 type Storage struct {

--- a/messages_test.go
+++ b/messages_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	xml "github.com/alist-org/gofakes3/xml"
+	xml "github.com/akang943578/gofakes3/xml"
 )
 
 func TestObjectListAddPrefix(t *testing.T) {

--- a/option_autobucket_test.go
+++ b/option_autobucket_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/akang943578/gofakes3"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/alist-org/gofakes3"
 )
 
 const autoBucket = "autobucket"

--- a/s3mem/backend.go
+++ b/s3mem/backend.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alist-org/gofakes3"
-	"github.com/alist-org/gofakes3/internal/goskipiter"
+	"github.com/akang943578/gofakes3"
+	"github.com/akang943578/gofakes3/internal/goskipiter"
 )
 
 var (

--- a/s3mem/bucket.go
+++ b/s3mem/bucket.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/alist-org/gofakes3"
-	"github.com/alist-org/gofakes3/internal/s3io"
+	"github.com/akang943578/gofakes3"
+	"github.com/akang943578/gofakes3/internal/s3io"
 	"github.com/ryszard/goskiplist/skiplist"
 )
 

--- a/s3mem/versionid.go
+++ b/s3mem/versionid.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/alist-org/gofakes3"
+	"github.com/akang943578/gofakes3"
 )
 
 var add1 = new(big.Int).SetInt64(1)

--- a/s3mem/versionid_test.go
+++ b/s3mem/versionid_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alist-org/gofakes3"
+	"github.com/akang943578/gofakes3"
 )
 
 func TestVersionID(t *testing.T) {

--- a/signature/signature-errors.go
+++ b/signature/signature-errors.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"net/http"
 
-	"github.com/alist-org/gofakes3/xml"
+	"github.com/akang943578/gofakes3/xml"
 )
 
 // ErrorCode is code[int] of APIError

--- a/signature/signature-errors.go
+++ b/signature/signature-errors.go
@@ -38,7 +38,7 @@ const (
 	errUnsignedHeaders
 	errMissingDateHeader
 	errMalformedDate
-	errUnsupportAlgorithm
+	ErrUnsupportAlgorithm
 	errSignatureDoesNotMatch
 
 	// ErrNone is None(err=nil)
@@ -108,7 +108,7 @@ var errorCodes = errorCodeMap{
 		Description:    "Invalid date format header, expected to be in ISO8601, RFC1123 or RFC1123Z time format.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	errUnsupportAlgorithm: {
+	ErrUnsupportAlgorithm: {
 		Code:           "UnsupportedAlgorithm",
 		Description:    "Encountered an unsupported algorithm.",
 		HTTPStatusCode: http.StatusBadRequest,

--- a/signature/signature-v2-parser.go
+++ b/signature/signature-v2-parser.go
@@ -1,0 +1,32 @@
+package signature
+
+import (
+	"strings"
+)
+
+// Parses signature version '2' header of the following form.
+//
+//	Authorization: AWS NXM00iAJpLvPYC94VRDd:q20e3MP/dZOpnzBZTvo619ONSpU=
+func ParseSignV2(v2Auth string) (sv signV2Values, err ErrorCode) {
+	if !strings.HasPrefix(v2Auth, signV2Algorithm) {
+		return sv, ErrUnsupportAlgorithm
+	}
+
+	rawCred := strings.ReplaceAll(strings.TrimPrefix(v2Auth, signV2Algorithm), " ", "")
+
+	signV2Values := signV2Values{}
+
+	authFields := strings.Split(strings.TrimSpace(rawCred), ":")
+	if len(authFields) != 2 {
+		return sv, errMissingFields
+	}
+
+	credential := CredentialsV2{
+		AccessKey: authFields[0],
+	}
+	signV2Values.Credential = credential
+	signV2Values.Signature = authFields[1]
+
+	// Return the structure here.
+	return signV2Values, ErrNone
+}

--- a/signature/signature-v2.go
+++ b/signature/signature-v2.go
@@ -1,0 +1,203 @@
+package signature
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	logger "github.com/sirupsen/logrus"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// ref: https://github.com/minio/minio/cmd/auth-handler.go
+
+const (
+	signV2Algorithm = "AWS"
+)
+
+// AWS S3 Signature V2 calculation rule is give here:
+// http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationStringToSign
+
+// Whitelist resource list that will be used in query string for signature-V2 calculation.
+var resourceList = []string{
+	"acl",
+	"lifecycle",
+	"location",
+	"logging",
+	"notification",
+	"partNumber",
+	"policy",
+	"requestPayment",
+	"torrent",
+	"uploadId",
+	"uploads",
+	"versionId",
+	"versioning",
+	"versions",
+	"website",
+}
+
+// CredentialsV2 - for signature-V2 calculation
+type CredentialsV2 struct {
+	AccessKey string
+	SecretKey string
+}
+
+type signV2Values struct {
+	Credential CredentialsV2
+	Signature  string
+}
+
+var log = logger.New()
+
+// Sign - return the Authorization header value.
+func (c CredentialsV2) SignV2(method string,
+	encodedResource string,
+	encodedQuery string,
+	headers http.Header,
+	expires string) string {
+	canonicalHeaaders := canonicalizedAmzHeadersV2(headers)
+	if len(canonicalHeaaders) > 0 {
+		canonicalHeaaders += "\n"
+	}
+
+	date := headers.Get("Date")
+	if expires != "" {
+		date = expires
+	}
+
+	stringToSign := strings.Join([]string{
+		method,
+		headers.Get("Content-MD5"),
+		headers.Get("Content-Type"),
+		date,
+		canonicalHeaaders,
+	}, "\n") + canonicalizedResourceV2(encodedResource, encodedQuery)
+
+	hm := hmac.New(sha1.New, []byte(c.SecretKey))
+	log.Debugf("stringToSign: %s", stringToSign)
+	hm.Write([]byte(stringToSign))
+	signature := base64.StdEncoding.EncodeToString(hm.Sum(nil))
+	return signature
+	//return fmt.Sprintf("%s %s:%s", SignV2Algorithm, c.AccessKey, signature)
+}
+
+// Return canonical headers.
+func canonicalizedAmzHeadersV2(headers http.Header) string {
+	var keys []string
+	keyval := make(map[string]string)
+	for key := range headers {
+		lkey := strings.ToLower(key)
+		if !strings.HasPrefix(lkey, "x-amz-") {
+			continue
+		}
+		keys = append(keys, lkey)
+		keyval[lkey] = strings.Join(headers[key], ",")
+	}
+	sort.Strings(keys)
+	var canonicalHeaders []string
+	for _, key := range keys {
+		canonicalHeaders = append(canonicalHeaders, key+":"+keyval[key])
+	}
+	return strings.Join(canonicalHeaders, "\n")
+}
+
+// Return canonical resource string.
+func canonicalizedResourceV2(encodedPath string, encodedQuery string) string {
+	queries := strings.Split(encodedQuery, "&")
+	keyval := make(map[string]string)
+	for _, query := range queries {
+		key := query
+		val := ""
+		index := strings.Index(query, "=")
+		if index != -1 {
+			key = query[:index]
+			val = query[index+1:]
+		}
+		keyval[key] = val
+	}
+	var canonicalQueries []string
+	for _, key := range resourceList {
+		val, ok := keyval[key]
+		if !ok {
+			continue
+		}
+		if val == "" {
+			canonicalQueries = append(canonicalQueries, key)
+			continue
+		}
+		canonicalQueries = append(canonicalQueries, key+"="+val)
+	}
+	if len(canonicalQueries) == 0 {
+		return encodedPath
+	}
+	// the queries will be already sorted as resourceList is sorted.
+	return encodedPath + "?" + strings.Join(canonicalQueries, "&")
+}
+
+func V2SignVerify(r *http.Request) ErrorCode {
+	req := *r
+
+	// Save authorization header.
+	// example: AWS NXM00iAJpLvPYC94VXXX:q20e3MP/dZOpnzBZTvo619OXXXX=
+	v2Auth := req.Header.Get(headerAuth)
+	expires := ""
+	if v2Auth == "" {
+		queryf := req.URL.Query()
+
+		urlEncodedSignature := queryf.Get("Signature")
+		signature, err := url.QueryUnescape(urlEncodedSignature)
+		if err != nil {
+			log.Warnf("Error decoding signature: %s", urlEncodedSignature)
+			return errCredMalformed
+		}
+
+		expires = queryf.Get("Expires")
+
+		v2Auth = fmt.Sprintf("%s %s:%s", signV2Algorithm, queryf.Get("AWSAccessKeyId"), signature)
+		if v2Auth == "" {
+			return errMissingCredTag
+		}
+	}
+
+	// Get the AWS access key and secret key
+	signV2Values, Err := ParseSignV2(v2Auth)
+	if Err != ErrNone {
+		return Err
+	}
+
+	credential := signV2Values.Credential
+	accessKey := credential.AccessKey
+	cred, _, Err := checkKeyValid(r, accessKey)
+	if Err != ErrNone {
+		return Err
+	}
+
+	secretKey := cred.SecretKey
+	credential.SecretKey = secretKey
+	receivedSignature := signV2Values.Signature
+	log.Debugf("receivedSignature: %s", receivedSignature)
+
+	encodedResource := req.URL.RawPath
+	encodedQuery := req.URL.RawQuery
+	if encodedResource == "" {
+		splits := strings.Split(req.URL.Path, "?")
+		if len(splits) > 0 {
+			encodedResource = splits[0]
+		}
+	}
+
+	// Create the string to sign
+	expectedSignature := credential.SignV2(req.Method, encodedResource, encodedQuery, req.Header, expires)
+	log.Debugf("expectedSignature: %s", expectedSignature)
+
+	// Compare the received signature with the expected signature
+	if receivedSignature != expectedSignature {
+		return errSignatureDoesNotMatch
+	}
+
+	return ErrNone
+}

--- a/signature/signature-v4-parser.go
+++ b/signature/signature-v4-parser.go
@@ -92,7 +92,7 @@ func extractFields(signElement, fieldName string) (string, ErrorCode) {
 func ParseSignV4(v4Auth string) (sv signValues, err ErrorCode) {
 
 	if !strings.HasPrefix(v4Auth, signV4Algorithm) {
-		return sv, errUnsupportAlgorithm
+		return sv, ErrUnsupportAlgorithm
 	}
 
 	rawCred := strings.ReplaceAll(strings.TrimPrefix(v4Auth, signV4Algorithm), " ", "")

--- a/signature/signature-v4_test.go
+++ b/signature/signature-v4_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/akang943578/gofakes3/signature"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
-	"github.com/alist-org/gofakes3/signature"
 )
 
 //nolint:all

--- a/uploader.go
+++ b/uploader.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alist-org/gofakes3/internal/goskipiter"
+	"github.com/akang943578/gofakes3/internal/goskipiter"
 	"github.com/ryszard/goskiplist/skiplist"
 )
 

--- a/uploader_test.go
+++ b/uploader_test.go
@@ -3,7 +3,7 @@ package gofakes3_test
 import (
 	"testing"
 
-	"github.com/alist-org/gofakes3"
+	"github.com/akang943578/gofakes3"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 


### PR DESCRIPTION
Implement AWS Signature V2. Some client can only use Signature V2 because V4 is not implemented totally, like Seafile, so implement Signature V2 to support them.